### PR TITLE
Add flag to prediction skeleton to only fetch data

### DIFF
--- a/SkeletonPredictionStudy/R/Main.R
+++ b/SkeletonPredictionStudy/R/Main.R
@@ -52,6 +52,7 @@
 #' @param createShiny          Create a shiny app with the results
 #' @param createJournalDocument Do you want to create a template journal document populated with results?
 #' @param analysisIdDocument   Which Analysis_id do you want to create the document for?
+#' @param onlyFetchData        Only fetch data for the analyses without fitting models. Setting this flag will overwrite your input provided to the runAnalyses and createCohorts parameters.
 #' @param verbosity            Sets the level of the verbosity. If the log level is at or higher in priority than the logger threshold, a message will print. The levels are:
 #'                                         \itemize{
 #'                                         \item{DEBUG}{Highest verbosity showing all debug statements}
@@ -114,6 +115,7 @@ execute <- function(connectionDetails,
                     createShiny = F,
                     createJournalDocument = F,
                     analysisIdDocument = 1,
+                    onlyFetchData = F,
                     verbosity = "INFO",
                     cdmVersion = 5,
                     cohortVariableSetting = NULL) {
@@ -127,7 +129,7 @@ execute <- function(connectionDetails,
     createPlpProtocol(outputFolder)
   }
   
-  if (createCohorts) {
+  if (createCohorts || onlyFetchData) {
     ParallelLogger::logInfo("Creating cohorts")
     createCohorts(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
@@ -223,8 +225,14 @@ execute <- function(connectionDetails,
     
   }
   
-  if(runAnalyses){
-    ParallelLogger::logInfo("Running predictions")
+  if(runAnalyses || onlyFetchData){
+    
+    if(onlyFetchData) {
+      ParallelLogger::logInfo("Only fetching data")
+    } else {
+      ParallelLogger::logInfo("Running predictions")
+    }
+    
     predictionAnalysisListFile <- system.file("settings",
                                               "predictionAnalysisList.json",
                                               package = "SkeletonPredictionStudy")
@@ -240,6 +248,7 @@ execute <- function(connectionDetails,
     predictionAnalysisList$cdmVersion = cdmVersion
     predictionAnalysisList$outputFolder = outputFolder
     predictionAnalysisList$verbosity = verbosity
+    predictionAnalysisList$onlyFetchData = onlyFetchData
     
     if(!is.null(cohortVariableSetting)){
       ParallelLogger::logInfo("Adding custom covariates to analysis settings")

--- a/SkeletonPredictionStudy/man/SkeletonPredictionStudy.Rd
+++ b/SkeletonPredictionStudy/man/SkeletonPredictionStudy.Rd
@@ -4,6 +4,3 @@
 \name{SkeletonPredictionStudy}
 \alias{SkeletonPredictionStudy}
 \title{SkeletonPredictionStudy}
-\description{
-SkeletonPredictionStudy
-}

--- a/SkeletonPredictionStudy/man/execute.Rd
+++ b/SkeletonPredictionStudy/man/execute.Rd
@@ -25,6 +25,7 @@ execute(
   createShiny = F,
   createJournalDocument = F,
   analysisIdDocument = 1,
+  onlyFetchData = F,
   verbosity = "INFO",
   cdmVersion = 5,
   cohortVariableSetting = NULL
@@ -83,6 +84,8 @@ in packaged results.}
 \item{createJournalDocument}{Do you want to create a template journal document populated with results?}
 
 \item{analysisIdDocument}{Which Analysis_id do you want to create the document for?}
+
+\item{onlyFetchData}{Only fetch data for the analyses without fitting models. Setting this flag will overwrite your input provided to the runAnalyses and createCohorts parameters.}
 
 \item{verbosity}{Sets the level of the verbosity. If the log level is at or higher in priority than the logger threshold, a message will print. The levels are:
 \itemize{


### PR DESCRIPTION
This flag to only fetch data has already been added to the PLP package. I suggest to also add this flag to the prediction skeleton.

By default the `onlyFetchData` flag is set to`FALSE`. If set to `TRUE`, it will overwrite the settings of the `createCohorts` and `runAnalyses` parameters of the prediction skeleton's execution function and only fetch the data objects without running the prediction analyses.